### PR TITLE
added create_doc_element_list to transform doc list to an element.

### DIFF
--- a/src/bson.ml
+++ b/src/bson.ml
@@ -75,6 +75,7 @@ let create_double v = Double v;;
 let create_string v = String v;;
 let create_doc_element v = Document v;;
 let create_list l = Array l;;
+let create_doc_element_list l = create_list (List.map create_doc_element l);;
 let create_generic_binary v = Binary (Generic v);;
 let create_function_binary v = Binary (Function v);;
 let create_uuid_binary v = Binary (UUID v);;

--- a/src/bson.mli
+++ b/src/bson.mli
@@ -75,6 +75,7 @@ val create_double : float -> element;;
 val create_string : string -> element;;
 val create_doc_element : t -> element;;
 val create_list : element list -> element;;
+val create_doc_element_list : t list -> element;;
 val create_user_binary : string -> element;;
 val create_objectId : string -> element;;
 val create_boolean : bool -> element;;


### PR DESCRIPTION
It is very useful to implement mongo query operators.
It will exist anyway, so why not share it.
