### PR TITLE
[fix] allowing list to have more than 208 elements

### DIFF
--- a/src/bson.ml
+++ b/src/bson.ml
@@ -190,7 +190,7 @@ let encode_cstring buf cs =
 let list_to_doc l = (* we need to transform the list to a doc with key as incrementing from '0' *)
   let rec to_doc i acc = function
     | [] -> acc
-    | hd::tl -> to_doc (i+1) (add_element (String.make 1 (Char.chr (i+48))) hd acc) tl
+    | hd::tl -> to_doc (i+1) (add_element (string_of_int i) hd acc) tl
   in
   to_doc 0 empty l;;
 


### PR DESCRIPTION
Xinuo could you check this out ?

The semantic of the id change a bit:
Before: (from ascii)
9 -> '9'
10 -> ':'
11 -> ';'
12 -> '<'
Now:
10 -> "10"
11 -> "11"
12 -> "12"

I'm not sure why the id where created this way, but since it works until the char overflow I am worried that changing the semantic do not follow the specification of bson. I change the semantic of the id it would be good if you can check if this follow the spec (from my understanding it is, since the id is consider as the label of a document). It seems to work fine on my side.
