### PR TITLE
Fix compilation for 4.06.1

### DIFF
--- a/setup.ml
+++ b/setup.ml
@@ -241,13 +241,7 @@ module OASISString = struct
       raise Not_found
 
 
-  let replace_chars f s =
-    let buf = String.make (String.length s) 'X' in
-      for i = 0 to String.length s - 1 do
-        buf.[i] <- f s.[i]
-      done;
-      buf
-
+  let replace_chars = String.map
 
 end
 


### PR DESCRIPTION
fix(setup) use String.map instead of custom oasis implementation - implementation does not compile on 4.06.1

Thanks very much for your work on `bson`, I use the package in this project : https://github.com/dbousque/lymp. `opam install bson` currently fails on 4.06.1, due to the depreciation of `String.set` used in the `replace_chars` method in `setup.ml` (oasis). You can read more about it here : https://github.com/dbousque/lymp/issues/13. This PR fixes it, it would be amazing if you could accept it and make a new release on opam :) Alternatively, I guess we could regenerate `setup.ml`. Let me know if I can help you further.